### PR TITLE
Redirect old homepage path to new location

### DIFF
--- a/open-watcom/index.html
+++ b/open-watcom/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<script>
+// Redirect old homepage URL to new location
+window.location.replace(window.location.origin);
+</script>
+</html>


### PR DESCRIPTION
Many places around the web (including search engines) have links to the
old homepage URL. This JavaScript redirect will prevent those links from
breaking!