### PR TITLE
styles: improve readability

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1,14 +1,15 @@
-@import url(https://fonts.googleapis.com/css?family=Lato:300italic,700italic,300,700);
+@import url(https://fonts.googleapis.com/css?family=Lato:400italic,700italic,400,700);
 
 body {
   padding:50px;
   font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color:#777;
-  font-weight:300;
+  color:black;
+  /* Lato only has 100, 300, 400, 700, 900 weights. 300 is too thin for comfort. */
+  font-weight:400;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color:#222;
+  color:black;
   margin:0 0 20px;
 }
 
@@ -25,11 +26,11 @@ h1 {
 }
 
 h2 {
-  color:#393939;
+  color:black;
 }
 
 h3, h4, h5, h6 {
-  color:#494949;
+  color:black;
 }
 
 a {
@@ -40,7 +41,7 @@ a {
 
 a small {
   font-size:11px;
-  color:#777;
+  color:black;
   margin-top:-0.6em;
   display:block;
 }
@@ -58,8 +59,8 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
-  color:#333;
+  font-family:Monaco, 'Bitstream Vera Sans Mono', 'Lucida Console', Terminal, monospace;
+  color:black;
   font-size:12px;
 }
 
@@ -83,12 +84,12 @@ th, td {
 }
 
 dt {
-  color:#444;
+  color:black;
   font-weight:700;
 }
 
 th {
-  color:#444;
+  color:black;
 }
 
 img {
@@ -139,7 +140,7 @@ header ul a {
 }
 
 strong {
-  color:#222;
+  color:black;
   font-weight:700;
 }
 
@@ -156,7 +157,7 @@ header ul li + li + li {
 header ul a strong {
   font-size:14px;
   display:block;
-  color:#222;
+  color:black;
 }
 
 section {
@@ -250,6 +251,6 @@ footer {
   body {
     padding:0.4in;
     font-size:12pt;
-    color:#444;
+    color:black;
   }
 }


### PR DESCRIPTION
it's very hard to text that is both thin (300) and grey (#777777). Don't do that.

I tried applying the black color change first, but apparently Lato 300 is not even readable when black given the small size it's at.